### PR TITLE
Add Node.js wrapper for dashboard

### DIFF
--- a/dashboard-app/README.md
+++ b/dashboard-app/README.md
@@ -1,0 +1,12 @@
+# Dashboard App
+
+Este diretório contém um exemplo simples de aplicação Node.js para servir o dashboard do Agnus WhatsApp Manager.
+
+## Instruções
+
+1. Copie o código HTML completo do dashboard para o arquivo `index.html` (substitua o conteúdo de exemplo).
+2. Instale as dependências executando `npm install` dentro da pasta `dashboard-app`.
+3. Inicie o servidor com `npm start`.
+4. Abra `http://localhost:3000` no navegador para acessar o dashboard.
+
+O servidor utiliza **Express** apenas para servir os arquivos estáticos.

--- a/dashboard-app/index.html
+++ b/dashboard-app/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agnus WhatsApp Manager - Dashboard Executivo</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <h1>Dashboard</h1>
+    <p>Substitua este arquivo index.html com o conteúdo completo do seu dashboard.</p>
+</body>
+</html>

--- a/dashboard-app/package.json
+++ b/dashboard-app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dashboard-app",
+  "version": "1.0.0",
+  "description": "Simple server for Agnus WhatsApp Manager dashboard",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/dashboard-app/server.js
+++ b/dashboard-app/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname)));
+
+app.listen(PORT, () => {
+  console.log(`Dashboard running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create `dashboard-app` example folder with Node.js server
- include placeholders for index.html and instructions in README

## Testing
- `node dashboard-app/server.js` *(fails: express not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686132ac09c0832e94a4378879c117a5